### PR TITLE
Enable runtime environment config

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,53 +1,72 @@
+import 'dotenv/config';
+
+const {
+  API_BASE_URL,
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  OPENAI_API_KEY,
+  EAS_PROJECT_ID,
+} = process.env;
+
+const fallbackSupabaseUrl = 'https://zvfeafmmtfplzpnocyjw.supabase.co';
+const fallbackSupabaseAnonKey =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmVhZm1tdGZwbHpwbm9jeWp3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMDE1NDMsImV4cCI6MjA3MTc3NzU0M30.PnSY6rFvczDiDucsyN0nr-luR_Jb6a6O2uAeZxgBiRI';
+
 export default {
   expo: {
     plugins: [
-      "expo-asset",
-      "expo-secure-store",
-      "expo-notifications",
-      "expo-font",
+      'expo-asset',
+      'expo-secure-store',
+      'expo-notifications',
+      'expo-font',
     ],
-    name: "FlynnAI",
-    slug: "FlynnAI",
-    version: "1.0.1",
-    orientation: "portrait",
-    icon: "./assets/images/icon.png",
-    userInterfaceStyle: "light",
+    name: 'FlynnAI',
+    slug: 'FlynnAI',
+    version: '1.0.1',
+    orientation: 'portrait',
+    icon: './assets/images/icon.png',
+    userInterfaceStyle: 'light',
     newArchEnabled: true,
     splash: {
-      image: "./assets/images/splash-icon.png",
-      resizeMode: "contain",
-      backgroundColor: "#3B82F6"
+      image: './assets/images/splash-icon.png',
+      resizeMode: 'contain',
+      backgroundColor: '#3B82F6',
     },
     ios: {
       supportsTablet: true,
-      bundleIdentifier: "com.flynnai.app",
-      deploymentTarget: "13.4",
+      bundleIdentifier: 'com.flynnai.app',
+      deploymentTarget: '13.4',
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
-        NSCameraUsageDescription: "FlynnAI uses the camera to capture screenshots of job details, quotes, and work orders. This helps automatically extract information and create calendar events for your business.",
-        NSPhotoLibraryUsageDescription: "FlynnAI accesses your photo library to select images containing job details that can be automatically processed into calendar events and client information.",
-        NSMicrophoneUsageDescription: "FlynnAI uses the microphone to record and transcribe phone calls with clients to automatically capture job details and create bookings.",
-        NSUserNotificationUsageDescription: "FlynnAI sends push notifications when new jobs are created so you never miss important follow-ups."
-      }
+        NSCameraUsageDescription:
+          'FlynnAI uses the camera to capture screenshots of job details, quotes, and work orders. This helps automatically extract information and create calendar events for your business.',
+        NSPhotoLibraryUsageDescription:
+          'FlynnAI accesses your photo library to select images containing job details that can be automatically processed into calendar events and client information.',
+        NSMicrophoneUsageDescription:
+          'FlynnAI uses the microphone to record and transcribe phone calls with clients to automatically capture job details and create bookings.',
+        NSUserNotificationUsageDescription:
+          'FlynnAI sends push notifications when new jobs are created so you never miss important follow-ups.',
+      },
     },
     android: {
       adaptiveIcon: {
-        foregroundImage: "./assets/images/adaptive-icon.png",
-        backgroundColor: "#3B82F6"
+        foregroundImage: './assets/images/adaptive-icon.png',
+        backgroundColor: '#3B82F6',
       },
       edgeToEdgeEnabled: true,
-      package: "com.flynnai.app"
+      package: 'com.flynnai.app',
     },
     web: {
-      favicon: "./assets/images/favicon.png"
+      favicon: './assets/images/favicon.png',
     },
     extra: {
-      // Hardcode for production builds to avoid undefined env vars
-      supabaseUrl: "https://zvfeafmmtfplzpnocyjw.supabase.co",
-      supabaseAnonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmVhZm1tdGZwbHpwbm9jeWp3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYyMDE1NDMsImV4cCI6MjA3MTc3NzU0M30.PnSY6rFvczDiDucsyN0nr-luR_Jb6a6O2uAeZxgBiRI",
+      apiBaseUrl: API_BASE_URL,
+      supabaseUrl: SUPABASE_URL || fallbackSupabaseUrl,
+      supabaseAnonKey: SUPABASE_ANON_KEY || fallbackSupabaseAnonKey,
+      openAIApiKey: OPENAI_API_KEY,
       eas: {
-        projectId: "799dd441-a3f1-4b18-a45d-bea10b3f9dc8"
-      }
-    }
-  }
+        projectId: EAS_PROJECT_ID || '799dd441-a3f1-4b18-a45d-bea10b3f9dc8',
+      },
+    },
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "babel-preset-expo": "~54.0.0",
         "buffer": "^6.0.3",
         "date-fns": "^4.1.0",
-        "dotenv": "^17.2.2",
         "expo": "~54.0.0",
         "expo-asset": "~12.0.9",
         "expo-av": "~14.0.7",
@@ -71,6 +70,7 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@types/react": "~19.1.10",
+        "dotenv": "^16.4.5",
         "jest": "^29.7.0",
         "supertest": "^7.1.4",
         "typescript": "~5.9.2"
@@ -5099,9 +5099,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5118,18 +5118,6 @@
       "dependencies": {
         "dotenv": "^16.4.5"
       },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -10775,18 +10763,6 @@
       },
       "peerDependencies": {
         "@babel/runtime": "^7.20.6"
-      }
-    },
-    "node_modules/react-native-dotenv/node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/react-native-elements": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-preset-expo": "~54.0.0",
     "buffer": "^6.0.3",
     "date-fns": "^4.1.0",
-    "dotenv": "^17.2.2",
     "expo": "~54.0.0",
     "expo-asset": "~12.0.9",
     "expo-av": "~14.0.7",
@@ -74,6 +73,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.1.10",
+    "dotenv": "^16.4.5",
     "jest": "^29.7.0",
     "supertest": "^7.1.4",
     "typescript": "~5.9.2"

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,17 @@
+import Constants from 'expo-constants';
+
+type ExpoExtra = {
+  apiBaseUrl?: string;
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+  openAIApiKey?: string;
+};
+
+const extra = (Constants.expoConfig?.extra ?? {}) as ExpoExtra;
+
+export const API_BASE_URL = extra.apiBaseUrl;
+export const SUPABASE_URL = extra.supabaseUrl;
+export const SUPABASE_ANON_KEY = extra.supabaseAnonKey;
+export const OPENAI_API_KEY = extra.openAIApiKey;
+
+export const getExpoExtra = () => extra;

--- a/src/services/OpenAIService.ts
+++ b/src/services/OpenAIService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { OPENAI_API_KEY } from '@env';
+import { OPENAI_API_KEY } from '../config/env';
 
 // Lazy initialization of OpenAI client
 let openai: OpenAI | null = null;

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,6 +1,5 @@
 import { AuthTokenStorage } from './authTokenStorage';
-import { APP_BASE_URL } from '@env';
-import Constants from 'expo-constants';
+import { API_BASE_URL } from '../config/env';
 import NetInfo from '@react-native-community/netinfo';
 
 declare const __DEV__: boolean | undefined;
@@ -16,15 +15,12 @@ const normalizeBaseUrl = (url?: string | null) => {
 };
 
 const resolveBaseUrl = () => {
-  const configBaseUrl = (Constants.expoConfig?.extra as { apiBaseUrl?: string } | undefined)?.apiBaseUrl;
-  const runtimeBaseUrl = APP_BASE_URL || configBaseUrl;
-
-  if (!runtimeBaseUrl) {
-    console.warn('[API] APP_BASE_URL is not set. Requests will fail until configured.');
+  if (!API_BASE_URL) {
+    console.warn('[API] API_BASE_URL is not set. Requests will fail until configured.');
     return '';
   }
 
-  return normalizeBaseUrl(runtimeBaseUrl);
+  return normalizeBaseUrl(API_BASE_URL);
 };
 
 const baseUrl = resolveBaseUrl();
@@ -104,7 +100,7 @@ const isRetryableError = (error: unknown): boolean => {
 
 const buildUrl = (path: string) => {
   if (!baseUrl) {
-    throw new Error('API base URL is not configured. Set APP_BASE_URL in your environment.');
+    throw new Error('API base URL is not configured. Set API_BASE_URL in your environment.');
   }
 
   if (!path.startsWith('/')) {


### PR DESCRIPTION
## Summary
- load dotenv in the Expo config to surface environment values through `extra`
- add a central env helper for reading `expo-constants` and update API/OpenAI services to use it
- move `dotenv` to devDependencies for configuration-time usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10f2e3674832cb5673e6011302a85