### PR TITLE
Surface voicemails on dashboard

### DIFF
--- a/src/components/dashboard/ActivityDetailsModal.tsx
+++ b/src/components/dashboard/ActivityDetailsModal.tsx
@@ -186,6 +186,47 @@ export const ActivityDetailsModal: React.FC<ActivityDetailsModalProps> = ({
     );
   };
 
+  const renderVoicemailPreview = () => {
+    const transcript = activity.metadata?.voicemailTranscript;
+    const recordingUrl = activity.metadata?.voicemailRecordingUrl;
+
+    if (!transcript && !recordingUrl) {
+      return null;
+    }
+
+    const handlePlay = () => {
+      if (!recordingUrl) return;
+      Linking.openURL(recordingUrl).catch(() => {
+        Alert.alert('Playback unavailable', 'Could not open the voicemail audio. Try again later.');
+      });
+    };
+
+    return (
+      <View style={styles.voicemailSection}>
+        <Text style={styles.sectionTitle}>Voicemail</Text>
+        {transcript ? (
+          <Text style={styles.voicemailTranscript}>
+            “{transcript.trim()}”
+          </Text>
+        ) : (
+          <Text style={styles.voicemailPlaceholder}>
+            Transcript not available yet. We’ll surface it as soon as processing finishes.
+          </Text>
+        )}
+        {recordingUrl && (
+          <TouchableOpacity
+            style={[styles.voicemailButton, { backgroundColor: colors.primary + '12' }]}
+            onPress={handlePlay}
+            activeOpacity={0.7}
+          >
+            <FlynnIcon name="play-outline" size={16} color={colors.primary} />
+            <Text style={[styles.voicemailButtonText, { color: colors.primary }]}>Listen to recording</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    );
+  };
+
   return (
     <Modal
       visible={visible}
@@ -229,6 +270,9 @@ export const ActivityDetailsModal: React.FC<ActivityDetailsModalProps> = ({
 
             {/* Metadata */}
             {renderActivityMetadata()}
+
+            {/* Voicemail preview */}
+            {renderVoicemailPreview()}
 
             {/* Action Buttons */}
             {renderActionButtons()}
@@ -429,5 +473,37 @@ const createStyles = (colors: any) => StyleSheet.create({
     ...typography.bodyMedium,
     color: colors.textSecondary,
     lineHeight: 22,
+  },
+
+  voicemailSection: {
+    marginBottom: spacing.lg,
+    gap: spacing.sm,
+  },
+
+  voicemailTranscript: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+    fontStyle: 'italic',
+    lineHeight: 22,
+  },
+
+  voicemailPlaceholder: {
+    ...typography.bodySmall,
+    color: colors.textTertiary,
+  },
+
+  voicemailButton: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+
+  voicemailButtonText: {
+    ...typography.bodySmall,
+    fontWeight: '600',
   },
 });

--- a/src/components/dashboard/VoicemailPreviewCard.tsx
+++ b/src/components/dashboard/VoicemailPreviewCard.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { FlynnIcon } from '../ui/FlynnIcon';
+import { useTheme } from '../../context/ThemeContext';
+import { spacing, typography, borderRadius, shadows } from '../../theme';
+import { DashboardVoicemail } from '../../services/voicemailService';
+import { formatActivityTime } from '../../services/dashboardService';
+
+interface VoicemailPreviewCardProps {
+  voicemail: DashboardVoicemail;
+  onPlayRecording?: (url: string) => void;
+  onOpenJob?: (jobId: string) => void;
+}
+
+export const VoicemailPreviewCard: React.FC<VoicemailPreviewCardProps> = ({
+  voicemail,
+  onPlayRecording,
+  onOpenJob,
+}) => {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+  const formattedTime = React.useMemo(() => {
+    return voicemail.recordedAt ? formatActivityTime(voicemail.recordedAt) : 'Just now';
+  }, [voicemail.recordedAt]);
+
+  const handlePlay = () => {
+    if (voicemail.recordingUrl) {
+      onPlayRecording?.(voicemail.recordingUrl);
+    }
+  };
+
+  const handleOpenJob = () => {
+    if (voicemail.jobId) {
+      onOpenJob?.(voicemail.jobId);
+    }
+  };
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={[styles.iconContainer, { backgroundColor: colors.primary + '15' }]}>
+          <FlynnIcon name="mic-outline" size={18} color={colors.primary} />
+        </View>
+        <View style={styles.headerText}>
+          <Text style={styles.caller}>{voicemail.fromNumber || 'Unknown caller'}</Text>
+          <Text style={styles.timestamp}>{formattedTime}</Text>
+        </View>
+        {voicemail.jobId ? (
+          <View style={[styles.badge, { backgroundColor: colors.success + '15' }]}>
+            <Text style={[styles.badgeText, { color: colors.success }]}>Converted</Text>
+          </View>
+        ) : voicemail.status ? (
+          <View style={[styles.badge, { backgroundColor: colors.gray100 }]}>
+            <Text style={[styles.badgeText, { color: colors.gray600 }]}>{voicemail.status}</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {voicemail.transcription ? (
+        <Text style={styles.transcript} numberOfLines={4}>
+          “{voicemail.transcription.trim()}”
+        </Text>
+      ) : (
+        <Text style={styles.placeholder}>
+          Transcript not available yet. We’ll notify you when it’s ready.
+        </Text>
+      )}
+
+      <View style={styles.actions}>
+        {voicemail.recordingUrl && (
+          <TouchableOpacity
+            style={[styles.actionButton, { backgroundColor: colors.primary + '12' }]}
+            activeOpacity={0.7}
+            onPress={handlePlay}
+          >
+            <FlynnIcon name="play-outline" size={16} color={colors.primary} />
+            <Text style={[styles.actionText, { color: colors.primary }]}>Listen to voicemail</Text>
+          </TouchableOpacity>
+        )}
+
+        {voicemail.jobId && (
+          <TouchableOpacity
+            style={[styles.actionButton, { backgroundColor: colors.primary + '08' }]}
+            activeOpacity={0.7}
+            onPress={handleOpenJob}
+          >
+            <FlynnIcon name="briefcase-outline" size={16} color={colors.primary} />
+            <Text style={[styles.actionText, { color: colors.primary }]}>Open event</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const createStyles = (colors: any) => StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    padding: spacing.md,
+    ...shadows.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.sm,
+  },
+  headerText: {
+    flex: 1,
+  },
+  caller: {
+    ...typography.bodyMedium,
+    color: colors.textPrimary,
+    fontWeight: '600',
+    marginBottom: spacing.xxxs,
+  },
+  timestamp: {
+    ...typography.caption,
+    color: colors.textTertiary,
+  },
+  badge: {
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.xxxs,
+    borderRadius: borderRadius.full,
+  },
+  badgeText: {
+    ...typography.caption,
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  transcript: {
+    ...typography.bodyMedium,
+    color: colors.textSecondary,
+    fontStyle: 'italic',
+    lineHeight: 20,
+    marginBottom: spacing.md,
+  },
+  placeholder: {
+    ...typography.bodySmall,
+    color: colors.textTertiary,
+    marginBottom: spacing.md,
+  },
+  actions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  actionButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    gap: spacing.xs,
+  },
+  actionText: {
+    ...typography.bodySmall,
+    fontWeight: '600',
+  },
+});

--- a/src/services/voicemailService.ts
+++ b/src/services/voicemailService.ts
@@ -1,0 +1,100 @@
+import { supabase } from './supabase';
+
+export interface DashboardVoicemail {
+  id: string;
+  callSid: string;
+  fromNumber?: string | null;
+  toNumber?: string | null;
+  recordedAt: string;
+  recordingUrl?: string | null;
+  transcription?: string | null;
+  jobId?: string | null;
+  status?: string | null;
+}
+
+interface RawVoicemailRow {
+  id?: string;
+  call_sid: string;
+  from_number?: string | null;
+  to_number?: string | null;
+  recorded_at?: string | null;
+  created_at?: string | null;
+  recording_url?: string | null;
+  transcription_status?: string | null;
+  transcription_text?: string | null;
+  status?: string | null;
+  job_id?: string | null;
+  transcriptions?: { text?: string | null } | { text?: string | null }[] | null;
+  jobs?:
+    | { id?: string | null; voicemail_transcript?: string | null; voicemail_recording_url?: string | null }
+    | Array<{ id?: string | null; voicemail_transcript?: string | null; voicemail_recording_url?: string | null }>
+    | null;
+}
+
+const getFirstRelationItem = <T>(value?: T | T[] | null): T | null => {
+  if (!value) return null;
+  return Array.isArray(value) ? (value.length > 0 ? value[0] ?? null : null) : value;
+};
+
+export const fetchRecentVoicemails = async (
+  userId: string,
+  limit = 5,
+): Promise<DashboardVoicemail[]> => {
+  const { data, error } = await supabase
+    .from('calls')
+    .select(
+      `
+        id,
+        call_sid,
+        from_number,
+        to_number,
+        recorded_at,
+        created_at,
+        recording_url,
+        transcription_status,
+        transcription_text,
+        status,
+        job_id,
+        transcriptions(text),
+        jobs:jobs!jobs_call_sid_fkey(id, voicemail_transcript, voicemail_recording_url)
+      `,
+    )
+    .eq('user_id', userId)
+    .order('recorded_at', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data as RawVoicemailRow[] | null ?? []).map(row => {
+    const transcriptionRelation = getFirstRelationItem(row.transcriptions);
+    const jobRelation = getFirstRelationItem(row.jobs);
+
+    const transcription = row.transcription_text
+      ?? transcriptionRelation?.text
+      ?? jobRelation?.voicemail_transcript
+      ?? null;
+
+    const recordingUrl = row.recording_url
+      ?? jobRelation?.voicemail_recording_url
+      ?? null;
+
+    const recordedAt = row.recorded_at
+      ?? row.created_at
+      ?? new Date().toISOString();
+
+    return {
+      id: row.id ?? row.call_sid,
+      callSid: row.call_sid,
+      fromNumber: row.from_number ?? null,
+      toNumber: row.to_number ?? null,
+      recordedAt,
+      recordingUrl,
+      transcription,
+      jobId: row.job_id ?? jobRelation?.id ?? null,
+      status: row.status ?? row.transcription_status ?? null,
+    } satisfies DashboardVoicemail;
+  });
+};


### PR DESCRIPTION
## Summary
- add a Supabase-backed voicemail service and lightweight UI card for recent recordings
- surface a Recent Voicemails section on the dashboard with playback/transcription snippets and extend upcoming event cards with voicemail context
- enrich dashboard activities and the activity detail modal with voicemail transcript + audio links for calendar events and call records

## Testing
- npm test -- --runTestsByPath tests/telephony.test.js *(fails: expected error copy differs from fixture messaging)*

------
https://chatgpt.com/codex/tasks/task_e_68e229f716fc832c97eaae91e5c7104a