### PR TITLE
Screenshot capture as recommended draft flow + voice/substance learning

### DIFF
--- a/ios-native/FlynnAI/Core/DeviceCapability.swift
+++ b/ios-native/FlynnAI/Core/DeviceCapability.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Lightweight device-capability checks used to tailor the capture-setup
+/// onboarding (Action Button vs Back Tap).
+enum DeviceCapability {
+
+    /// Hardware model identifier, e.g. "iPhone16,1". On the simulator this reflects
+    /// the simulated device via the SIMULATOR_MODEL_IDENTIFIER env var.
+    static var modelIdentifier: String {
+        if let sim = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] {
+            return sim
+        }
+        var info = utsname()
+        uname(&info)
+        let machine = withUnsafeBytes(of: &info.machine) { raw -> String in
+            let bytes = raw.bindMemory(to: CChar.self)
+            return String(cString: bytes.baseAddress!)
+        }
+        return machine
+    }
+
+    /// True for iPhones that ship with the Action Button: iPhone 15 Pro / Pro Max
+    /// (`iPhone16,1` / `iPhone16,2`) and every iPhone 16 and later (`iPhone17,*`
+    /// onward — future-proofed by major-number comparison).
+    static var hasActionButton: Bool {
+        let id = modelIdentifier
+        if id == "iPhone16,1" || id == "iPhone16,2" { return true }
+        guard id.hasPrefix("iPhone") else { return false }
+        let majorString = id.dropFirst("iPhone".count).prefix { $0 != "," }
+        if let major = Int(majorString), major >= 17 { return true }
+        return false
+    }
+}

--- a/ios-native/FlynnAI/Core/FlynnConfig.swift
+++ b/ios-native/FlynnAI/Core/FlynnConfig.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Static, non-secret app configuration.
+enum FlynnConfig {
+    /// Published iCloud link to the prebuilt "Take Screenshot → Capture with Flynn"
+    /// shortcut. Tapping it lets the user add the shortcut in one tap.
+    ///
+    /// To publish: in the Shortcuts app build a shortcut that runs the
+    /// **Take Screenshot** action and passes its output into the **Capture with
+    /// Flynn** intent, then Share → Copy iCloud Link and paste it here.
+    ///
+    /// While this is `nil`, the capture-setup screen shows the manual build steps
+    /// as a fallback.
+    static let captureShortcutURL: URL? = nil
+
+    /// The intent's title as it appears in the Shortcuts/Settings pickers — kept in
+    /// one place so onboarding copy and the AppIntent title stay in sync.
+    static let captureIntentName = "Capture with Flynn"
+}

--- a/ios-native/FlynnAI/Features/Onboarding/CaptureSetupStepView.swift
+++ b/ios-native/FlynnAI/Features/Onboarding/CaptureSetupStepView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+import UIKit
+
+/// Final onboarding step. Presents the two capture options — screenshot capture
+/// (recommended) and copy → keyboard (the universal fallback) — and, when the user
+/// picks screenshot, walks them through adding the shortcut and binding a gesture
+/// (Action Button or Back Tap, chosen by device).
+struct CaptureSetupStepView: View {
+    let onFinish: () -> Void
+
+    private enum Mode { case choose, screenshot }
+    @State private var mode: Mode = .choose
+    @State private var showBackTapAlt = false
+
+    var body: some View {
+        switch mode {
+        case .choose:     chooseView
+        case .screenshot: screenshotView
+        }
+    }
+
+    // MARK: Choose
+
+    private var chooseView: some View {
+        OnboardingScaffold(variant: 3) {
+            OnboardingHeadline(
+                eyebrow: "One last thing",
+                title: "Pick how you",
+                accentTitle: "capture messages",
+                subtitle: "Both work great and you can use either anytime. We recommend the screenshot way — it's one tap and never touches your clipboard."
+            )
+
+            captureCard(
+                badge: "RECOMMENDED",
+                icon: "text.viewfinder",
+                title: "Screenshot capture",
+                description: "Tap your gesture over any message — Flynn reads the screen and your replies are waiting in the keyboard. Nothing is saved to your camera roll.",
+                buttonTitle: "Set up screenshot capture",
+                variant: .primary
+            ) { withAnimation { mode = .screenshot } }
+
+            captureCard(
+                badge: nil,
+                icon: "doc.on.clipboard",
+                title: "Copy & paste",
+                description: "Works everywhere. Copy a message, open the Flynn keyboard, and tap a reply to insert it.",
+                buttonTitle: "Use copy & paste",
+                variant: .secondary
+            ) { onFinish() }
+        } footer: {
+            RetroTextButton(title: "I'll set this up later", action: onFinish)
+        }
+    }
+
+    private func captureCard(
+        badge: String?,
+        icon: String,
+        title: String,
+        description: String,
+        buttonTitle: String,
+        variant: RetroButton.Variant,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(OB.orange)
+                Text(title)
+                    .font(.custom(FlynnFontName.spaceGroteskBold, size: 20))
+                    .foregroundColor(OB.ink)
+                Spacer(minLength: 6)
+                if let badge {
+                    Text(badge)
+                        .font(.custom(FlynnFontName.spaceGroteskBold, size: 10))
+                        .tracking(1)
+                        .foregroundColor(OB.card)
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(Capsule().fill(OB.orange))
+                }
+            }
+            Text(description)
+                .font(.custom(FlynnFontName.interRegular, size: 15))
+                .foregroundColor(OB.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+            RetroButton(title: buttonTitle, variant: variant, action: action)
+                .padding(.top, 2)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 20, style: .continuous).fill(OB.card))
+        .overlay(RoundedRectangle(cornerRadius: 20, style: .continuous).stroke(OB.ink, lineWidth: OB.outline))
+    }
+
+    // MARK: Screenshot setup
+
+    private var screenshotView: some View {
+        OnboardingScaffold(variant: 0) {
+            OnboardingHeadline(
+                eyebrow: "Screenshot capture",
+                title: "Two taps to",
+                accentTitle: "set it up"
+            )
+
+            sectionTitle("1  Add the Flynn shortcut")
+            stepText("Adds a one-tap “\(FlynnConfig.captureIntentName)” shortcut that screenshots your screen and gets replies ready — without saving to your camera roll.")
+            if FlynnConfig.captureShortcutURL != nil {
+                RetroButton(title: "Add the Flynn shortcut", action: addShortcut)
+            } else {
+                manualShortcutSteps
+            }
+
+            sectionTitle("2  Choose your gesture")
+            gestureSection
+
+            RetroButton(title: "Open Settings", variant: .secondary, action: openSettings)
+                .padding(.top, 4)
+        } footer: {
+            RetroButton(title: "Done — finish setup", action: onFinish)
+            RetroTextButton(title: "Back", action: { withAnimation { mode = .choose } })
+        }
+    }
+
+    @ViewBuilder private var gestureSection: some View {
+        if DeviceCapability.hasActionButton {
+            stepText("Open Settings → Action Button, swipe to Shortcut, and choose “\(FlynnConfig.captureIntentName)”. A single press now triggers Flynn.")
+            Text("Heads up: this replaces your Action Button's current action (like Camera).")
+                .font(.custom(FlynnFontName.interRegular, size: 13))
+                .foregroundColor(OB.inkFaint)
+                .fixedSize(horizontal: false, vertical: true)
+            Button { withAnimation { showBackTapAlt.toggle() } } label: {
+                Text(showBackTapAlt ? "Hide Back Tap option" : "Want to keep your Action Button? Use Back Tap →")
+                    .font(.custom(FlynnFontName.interMedium, size: 14))
+                    .foregroundColor(OB.orange)
+            }
+            .buttonStyle(.plain)
+            if showBackTapAlt {
+                stepText(backTapInstruction)
+            }
+        } else {
+            stepText(backTapInstruction)
+        }
+    }
+
+    private var backTapInstruction: String {
+        "Open Settings → Accessibility → Touch → Back Tap → Triple Tap, then choose “\(FlynnConfig.captureIntentName)”. Triple-tap the back of your phone to trigger Flynn."
+    }
+
+    private var manualShortcutSteps: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            stepText("Open the Shortcuts app → New Shortcut, then:")
+            bullet("Add the “Take Screenshot” action.")
+            bullet("Add the “\(FlynnConfig.captureIntentName)” action and pass the screenshot into it.")
+        }
+    }
+
+    // MARK: Small building blocks
+
+    private func sectionTitle(_ s: String) -> some View {
+        Text(s)
+            .font(.custom(FlynnFontName.spaceGroteskBold, size: 17))
+            .foregroundColor(OB.ink)
+            .padding(.top, 6)
+    }
+
+    private func stepText(_ s: String) -> some View {
+        Text(s)
+            .font(.custom(FlynnFontName.interRegular, size: 15))
+            .foregroundColor(OB.inkSoft)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func bullet(_ s: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text("•").foregroundColor(OB.orange)
+            Text(s)
+                .font(.custom(FlynnFontName.interRegular, size: 15))
+                .foregroundColor(OB.inkSoft)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    // MARK: Actions
+
+    private func addShortcut() {
+        if let url = FlynnConfig.captureShortcutURL { UIApplication.shared.open(url) }
+    }
+
+    private func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) { UIApplication.shared.open(url) }
+    }
+}

--- a/ios-native/FlynnAI/Features/Onboarding/OnboardingCoordinator.swift
+++ b/ios-native/FlynnAI/Features/Onboarding/OnboardingCoordinator.swift
@@ -98,7 +98,9 @@ struct OnboardingCoordinator: View {
             case .practice:
                 PracticeStepView(onContinue: store.advance)
             case .installKeyboard:
-                InstallKeyboardStepView(onFinish: finish)
+                InstallKeyboardStepView(onContinue: store.advance)
+            case .captureSetup:
+                CaptureSetupStepView(onFinish: finish)
             }
         }
         .id(store.currentStep)

--- a/ios-native/FlynnAI/Features/Onboarding/OnboardingSteps.swift
+++ b/ios-native/FlynnAI/Features/Onboarding/OnboardingSteps.swift
@@ -455,13 +455,13 @@ struct ConnectCalendarStepView: View {
 // MARK: - Install keyboard (the one-off ask, value already shown)
 
 struct InstallKeyboardStepView: View {
-    let onFinish: () -> Void
+    let onContinue: () -> Void
 
     var body: some View {
         OnboardingScaffold(variant: 2) {
             HStack(alignment: .top) {
                 OnboardingHeadline(
-                    eyebrow: "Last step",
+                    eyebrow: "Almost there",
                     title: "Add the",
                     accentTitle: "Flynn keyboard",
                     subtitle: "This is how Flynn drafts replies right inside Messages. One-time setup — copy a message, switch to the Flynn keyboard, tap a reply."
@@ -474,7 +474,7 @@ struct InstallKeyboardStepView: View {
             instructionRow("3", "Tap Flynn and turn on “Allow Full Access” so it can draft from your copied message.")
         } footer: {
             RetroButton(title: "Open Settings", action: openSettings)
-            RetroButton(title: "I've added it — finish", variant: .secondary, action: onFinish)
+            RetroButton(title: "I've added it — next", variant: .secondary, action: onContinue)
         }
     }
 

--- a/ios-native/FlynnAI/Features/Onboarding/OnboardingStore.swift
+++ b/ios-native/FlynnAI/Features/Onboarding/OnboardingStore.swift
@@ -20,6 +20,7 @@ final class OnboardingStore {
         case paywall         = 6
         case practice        = 7
         case installKeyboard = 8
+        case captureSetup    = 9
 
         var id: Int { rawValue }
 
@@ -34,6 +35,7 @@ final class OnboardingStore {
             case .paywall:         return "Unlock Flynn"
             case .practice:        return "Try it once"
             case .installKeyboard: return "Add the Flynn keyboard"
+            case .captureSetup:    return "How you'll capture"
             }
         }
     }
@@ -186,27 +188,30 @@ final class OnboardingStore {
         }
         do {
             let session = try await client.auth.session
-            let row: Row = try await client
+            let rows: [Row] = try await client
                 .from("users")
                 .select("onboarding_completed, has_provisioned_phone")
                 .eq("id", value: session.user.id.uuidString)
-                .single()
+                .limit(1)
                 .execute()
                 .value
-            onboardingCompleted = row.onboarding_completed
-            hasProvisionedPhone = row.has_provisioned_phone ?? false
             verifiedPhone = session.user.phone
             demoUserId = session.user.id.uuidString
-
-            // Restore in-progress step if the user quit mid-onboarding last launch.
-            if row.onboarding_completed == false, let saved = Self.restoreStep() {
-                currentStep = saved
+            if let row = rows.first {
+                onboardingCompleted = row.onboarding_completed
+                hasProvisionedPhone = row.has_provisioned_phone ?? false
+                if row.onboarding_completed == false, let saved = Self.restoreStep() {
+                    currentStep = saved
+                }
+            } else {
+                // New user — no users row yet, always show onboarding.
+                onboardingCompleted = false
             }
-
             loadState = .loaded
         } catch {
             loadState = .error(error.localizedDescription)
-            onboardingCompleted = true
+            // Leave onboardingCompleted as nil — nil != true so onboarding shows,
+            // which is the safe default for both new users and transient errors.
         }
     }
 

--- a/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotDraftIntent.swift
+++ b/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotDraftIntent.swift
@@ -1,0 +1,81 @@
+import AppIntents
+import UniformTypeIdentifiers
+
+/// The bridge for Flynn's recommended capture flow. A user-built Shortcut runs
+/// "Take Screenshot" (which does NOT save to the camera roll) and passes the image
+/// straight into this intent's `screenshot` parameter. The intent runs in the
+/// background (`openAppWhenRun = false`): it OCRs the screenshot on-device, drafts
+/// replies, and stages them in the App Group for the Flynn keyboard to auto-load.
+///
+/// It never reads the clipboard, so there's no "pasting from…" banner.
+///
+/// The pipeline always stages *something* so the keyboard is never a dead end:
+/// finished drafts on success, otherwise the OCR'd messages with `needsDraft` so
+/// the keyboard generates them, or a `limitReached` marker for the free-tier cap.
+struct ScreenshotDraftIntent: AppIntent {
+    static let title: LocalizedStringResource = "Capture with Flynn"
+    static let description = IntentDescription(
+        "Reads the message on your screen and gets replies ready in the Flynn keyboard."
+    )
+
+    /// Run silently in the background — no app launch, latency hides in the switch
+    /// to the messaging app + keyboard.
+    static let openAppWhenRun: Bool = false
+
+    @Parameter(title: "Screenshot", supportedContentTypes: [.image])
+    var screenshot: IntentFile
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        // 1. OCR the screenshot on-device.
+        let text: String
+        do {
+            text = try await ScreenshotOCR.recognizeText(from: screenshot.data)
+        } catch {
+            return .result(dialog: "Couldn't read that screenshot — try copying the message instead.")
+        }
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .result(dialog: "No message text found in that screenshot.")
+        }
+        let messages = [trimmed]
+
+        // 2. Generate drafts now if we can; otherwise stage the messages so the
+        //    keyboard drafts them. Either way the keyboard has work to show.
+        do {
+            let drafts = try await KeyboardDraftClient.fetchDrafts(messages: messages, source: "screenshot")
+            SharedStore.stageScreenshotDraft(
+                StagedScreenshotDraft(messages: messages, drafts: drafts)
+            )
+            return .result(dialog: "Replies are ready — open the Flynn keyboard.")
+        } catch KeyboardDraftClient.ClientError.limitReached {
+            SharedStore.stageScreenshotDraft(
+                StagedScreenshotDraft(messages: messages, limitReached: true)
+            )
+            return .result(dialog: "You're out of free drafts today — open Flynn to go unlimited.")
+        } catch {
+            // Missing token / network / decode — let the keyboard finish the draft.
+            SharedStore.stageScreenshotDraft(
+                StagedScreenshotDraft(messages: messages, needsDraft: true)
+            )
+            return .result(dialog: "Captured — open the Flynn keyboard to see your replies.")
+        }
+    }
+}
+
+/// Exposes the intent to the Shortcuts app and Spotlight so the user can build the
+/// "Take Screenshot → Capture with Flynn" shortcut and bind it to a gesture.
+struct FlynnShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ScreenshotDraftIntent(),
+            phrases: [
+                "Capture with \(.applicationName)",
+                "Draft a reply with \(.applicationName)"
+            ],
+            shortTitle: "Capture with Flynn",
+            systemImageName: "text.viewfinder"
+        )
+    }
+}

--- a/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotOCR.swift
+++ b/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotOCR.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Vision
+import UIKit
+import ImageIO
+
+/// On-device OCR for a captured screenshot. Uses the modern Vision Swift API
+/// (`RecognizeTextRequest`, iOS 18+) at the accurate level with language
+/// correction. Fully offline, no permissions — the image arrives as bytes from
+/// the Shortcut's "Take Screenshot" action via an `IntentFile`.
+enum ScreenshotOCR {
+
+    enum OCRError: Error { case badImage }
+
+    /// Recognize text in the screenshot data and return it as a single
+    /// conversation string (lines joined top-to-bottom). Empty string if nothing
+    /// readable was found.
+    static func recognizeText(from data: Data) async throws -> String {
+        guard let cgImage = makeCGImage(from: data) else { throw OCRError.badImage }
+
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        let observations = try await request.perform(on: cgImage)
+
+        // Reconstruct reading order: top-to-bottom (Vision's normalized origin is
+        // bottom-left, so higher y = higher on screen), then left-to-right.
+        let lines: [String] = observations
+            .sorted { lhs, rhs in
+                let l = lhs.boundingBox.cgRect
+                let r = rhs.boundingBox.cgRect
+                if abs(l.midY - r.midY) > 0.02 { return l.midY > r.midY }
+                return l.minX < r.minX
+            }
+            .compactMap { $0.topCandidates(1).first?.string }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Screenshots are PNG and decode via `UIImage`; keep a `CGImageSource`
+    /// fallback for other encodings (HEIC, CIImage-backed) where `.cgImage` is nil.
+    private static func makeCGImage(from data: Data) -> CGImage? {
+        if let cg = UIImage(data: data)?.cgImage { return cg }
+        guard
+            let src = CGImageSourceCreateWithData(data as CFData, nil),
+            let cg = CGImageSourceCreateImageAtIndex(src, 0, nil)
+        else { return nil }
+        return cg
+    }
+}

--- a/ios-native/FlynnKeyboard/KeyboardViewController.swift
+++ b/ios-native/FlynnKeyboard/KeyboardViewController.swift
@@ -17,11 +17,10 @@ final class KeyboardViewController: UIInputViewController {
     private let redraftButton = UIButton(type: .system)
     private let nextKeyboardButton = UIButton(type: .system)
 
-    // Results (the swipeable single-reply card + pager)
+    // Results (the swipeable single-reply card)
+    // ‹ and › are embedded inside the card so the swipe affordance is always visible.
     private let card = UIControl()
     private let draftLabel = UILabel()
-    private let hintLabel = UILabel()
-    private let pager = UIStackView()
     private let prevButton = UIButton(type: .system)
     private let nextButton = UIButton(type: .system)
     private let pageLabel = UILabel()
@@ -36,7 +35,15 @@ final class KeyboardViewController: UIInputViewController {
     private var isDrafting = false
     private var heightConstraint: NSLayoutConstraint?
 
+    // Where the currently-shown drafts came from ("clipboard" or "screenshot") and
+    // the source messages — both sent with the pick so the backend learns by source.
+    private var currentSource = "clipboard"
+    private var sourceMessages: [String] = []
+
     private static let flynnOrange = UIColor(red: 0.984, green: 0.357, blue: 0.118, alpha: 1) // #FB5B1E
+    private static let obCream     = UIColor(red: 0.957, green: 0.902, blue: 0.808, alpha: 1) // #F4E6CE
+    private static let obCard      = UIColor(red: 1.000, green: 0.984, blue: 0.957, alpha: 1) // #FFFBF4
+    private static let obInk       = UIColor(red: 0.173, green: 0.125, blue: 0.094, alpha: 1) // #2C2018
 
     // MARK: Lifecycle
 
@@ -66,11 +73,11 @@ final class KeyboardViewController: UIInputViewController {
     // MARK: UI
 
     private func buildUI() {
-        view.backgroundColor = .secondarySystemBackground
+        view.backgroundColor = Self.obCream
 
         container.axis = .vertical
-        container.spacing = 8
-        container.layoutMargins = UIEdgeInsets(top: 10, left: 14, bottom: 12, right: 14)
+        container.spacing = 10
+        container.layoutMargins = UIEdgeInsets(top: 12, left: 14, bottom: 14, right: 14)
         container.isLayoutMarginsRelativeArrangement = true
         container.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(container)
@@ -81,12 +88,12 @@ final class KeyboardViewController: UIInputViewController {
             container.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
         ])
 
-        // Header: title · Redraft · globe
+        // Header: Flynn · Business  ↻ Redraft  🌐
         titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
-        titleLabel.textColor = .secondaryLabel
+        titleLabel.textColor = Self.obInk.withAlphaComponent(0.6)
 
         redraftButton.setTitle("↻ Redraft", for: .normal)
-        redraftButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .medium)
+        redraftButton.titleLabel?.font = .systemFont(ofSize: 13, weight: .semibold)
         redraftButton.tintColor = Self.flynnOrange
         redraftButton.addTarget(self, action: #selector(onRedraft), for: .touchUpInside)
 
@@ -98,34 +105,78 @@ final class KeyboardViewController: UIInputViewController {
         header.axis = .horizontal; header.alignment = .center; header.spacing = 10
         container.addArrangedSubview(header)
 
-        // Card: one full reply, tap to insert, swipe to navigate.
-        card.backgroundColor = .tertiarySystemBackground
-        card.layer.cornerRadius = 16
+        // Card: cream background, ink border, full reply text.
+        // The ‹ › nav arrows are baked into the card so the swipe affordance is always visible.
+        card.backgroundColor = Self.obCard
+        card.layer.cornerRadius = 14
+        card.layer.borderWidth = 2
+        card.layer.borderColor = Self.obInk.cgColor
+        // brutalist offset shadow
+        card.layer.shadowColor = Self.obInk.cgColor
+        card.layer.shadowOffset = CGSize(width: 4, height: 4)
+        card.layer.shadowOpacity = 1
+        card.layer.shadowRadius = 0
         card.translatesAutoresizingMaskIntoConstraints = false
 
+        // Left arrow (always visible; dims when at first draft)
+        prevButton.setTitle("‹", for: .normal)
+        prevButton.titleLabel?.font = .systemFont(ofSize: 34, weight: .medium)
+        prevButton.setTitleColor(Self.flynnOrange, for: .normal)
+        prevButton.setTitleColor(Self.flynnOrange.withAlphaComponent(0.25), for: .disabled)
+        prevButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 4)
+        prevButton.addTarget(self, action: #selector(onPrev), for: .touchUpInside)
+        prevButton.translatesAutoresizingMaskIntoConstraints = false
+        prevButton.setContentHuggingPriority(.required, for: .horizontal)
+
         draftLabel.numberOfLines = 0
-        draftLabel.font = .systemFont(ofSize: 17)
-        draftLabel.textColor = .label
+        draftLabel.font = .systemFont(ofSize: 19, weight: .regular)
+        draftLabel.textColor = Self.obInk
         draftLabel.translatesAutoresizingMaskIntoConstraints = false
         draftLabel.isUserInteractionEnabled = false
 
-        hintLabel.text = "Tap to insert →"
-        hintLabel.font = .systemFont(ofSize: 11, weight: .semibold)
-        hintLabel.textColor = Self.flynnOrange
-        hintLabel.translatesAutoresizingMaskIntoConstraints = false
-        hintLabel.isUserInteractionEnabled = false
+        // Right arrow (always visible; dims when at last draft)
+        nextButton.setTitle("›", for: .normal)
+        nextButton.titleLabel?.font = .systemFont(ofSize: 34, weight: .medium)
+        nextButton.setTitleColor(Self.flynnOrange, for: .normal)
+        nextButton.setTitleColor(Self.flynnOrange.withAlphaComponent(0.25), for: .disabled)
+        nextButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: 10)
+        nextButton.addTarget(self, action: #selector(onNext), for: .touchUpInside)
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.setContentHuggingPriority(.required, for: .horizontal)
 
+        // Page dot / counter sits below draft text, centred
+        pageLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        pageLabel.textColor = Self.obInk.withAlphaComponent(0.45)
+        pageLabel.textAlignment = .center
+        pageLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        card.addSubview(prevButton)
         card.addSubview(draftLabel)
-        card.addSubview(hintLabel)
+        card.addSubview(nextButton)
+        card.addSubview(pageLabel)
         NSLayoutConstraint.activate([
-            draftLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: 14),
-            draftLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
-            draftLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
-            hintLabel.topAnchor.constraint(greaterThanOrEqualTo: draftLabel.bottomAnchor, constant: 8),
-            hintLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
-            hintLabel.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -10),
-            card.heightAnchor.constraint(greaterThanOrEqualToConstant: 132)
+            // left arrow hugs left edge, vertically centred on draft text
+            prevButton.leadingAnchor.constraint(equalTo: card.leadingAnchor),
+            prevButton.centerYAnchor.constraint(equalTo: draftLabel.centerYAnchor),
+
+            // draft text fills middle
+            draftLabel.topAnchor.constraint(equalTo: card.topAnchor, constant: 16),
+            draftLabel.leadingAnchor.constraint(equalTo: prevButton.trailingAnchor),
+            draftLabel.trailingAnchor.constraint(equalTo: nextButton.leadingAnchor),
+
+            // right arrow hugs right edge, vertically centred on draft text
+            nextButton.trailingAnchor.constraint(equalTo: card.trailingAnchor),
+            nextButton.centerYAnchor.constraint(equalTo: draftLabel.centerYAnchor),
+
+            // page counter below draft text
+            pageLabel.topAnchor.constraint(equalTo: draftLabel.bottomAnchor, constant: 8),
+            pageLabel.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 16),
+            pageLabel.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -16),
+            pageLabel.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -12),
+
+            card.heightAnchor.constraint(greaterThanOrEqualToConstant: 120),
         ])
+
         card.addTarget(self, action: #selector(onInsert), for: .touchUpInside)
         let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(onNext)); swipeLeft.direction = .left
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(onPrev)); swipeRight.direction = .right
@@ -133,33 +184,15 @@ final class KeyboardViewController: UIInputViewController {
         card.addGestureRecognizer(swipeRight)
         container.addArrangedSubview(card)
 
-        // Pager: ‹  1 / 4  ›
-        prevButton.setTitle("‹", for: .normal)
-        prevButton.titleLabel?.font = .systemFont(ofSize: 28, weight: .medium)
-        prevButton.addTarget(self, action: #selector(onPrev), for: .touchUpInside)
-        nextButton.setTitle("›", for: .normal)
-        nextButton.titleLabel?.font = .systemFont(ofSize: 28, weight: .medium)
-        nextButton.addTarget(self, action: #selector(onNext), for: .touchUpInside)
-        pageLabel.font = .systemFont(ofSize: 13, weight: .medium)
-        pageLabel.textColor = .secondaryLabel
-        pageLabel.textAlignment = .center
-        pageLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 60).isActive = true
-        pager.axis = .horizontal; pager.alignment = .center; pager.spacing = 24
-        pager.addArrangedSubview(prevButton)
-        pager.addArrangedSubview(pageLabel)
-        pager.addArrangedSubview(nextButton)
-        let pagerWrap = UIStackView(arrangedSubviews: [UIView(), pager, UIView()])
-        pagerWrap.axis = .horizontal
-        container.addArrangedSubview(pagerWrap)
-
         // Status + spinner (loading / access / empty states)
-        statusLabel.font = .systemFont(ofSize: 14)
-        statusLabel.textColor = .secondaryLabel
+        statusLabel.font = .systemFont(ofSize: 15)
+        statusLabel.textColor = Self.obInk.withAlphaComponent(0.55)
         statusLabel.numberOfLines = 0
         statusLabel.textAlignment = .center
         container.addArrangedSubview(statusLabel)
 
         spinner.hidesWhenStopped = true
+        spinner.color = Self.flynnOrange
         container.addArrangedSubview(spinner)
     }
 
@@ -167,7 +200,6 @@ final class KeyboardViewController: UIInputViewController {
 
     private func showResults() {
         card.isHidden = false
-        pager.superview?.isHidden = drafts.count <= 1
         statusLabel.isHidden = true
     }
 
@@ -175,17 +207,16 @@ final class KeyboardViewController: UIInputViewController {
         statusLabel.text = text
         statusLabel.isHidden = false
         card.isHidden = true
-        pager.superview?.isHidden = true
     }
 
     private func renderCard() {
         guard drafts.indices.contains(index) else { return }
         draftLabel.text = drafts[index]
+        // Show counter only when there are multiple drafts; hide when single.
+        pageLabel.isHidden = drafts.count <= 1
         pageLabel.text = "\(index + 1) / \(drafts.count)"
         prevButton.isEnabled = index > 0
         nextButton.isEnabled = index < drafts.count - 1
-        prevButton.alpha = prevButton.isEnabled ? 1 : 0.3
-        nextButton.alpha = nextButton.isEnabled ? 1 : 0.3
     }
 
     // MARK: Drafting
@@ -202,11 +233,40 @@ final class KeyboardViewController: UIInputViewController {
             return
         }
         if isDrafting { return }
+
+        // Recommended flow: a screenshot capture staged by the App Intent takes
+        // priority over the clipboard. Returns nil when there's nothing fresh, so
+        // the clipboard path below is untouched in the copy→keyboard case.
+        if let staged = SharedStore.freshStagedScreenshotDraft() {
+            consumeStaged(staged)
+            return
+        }
+
         let cc = UIPasteboard.general.changeCount
         if cc == lastChangeCount && !drafts.isEmpty {
             showResults(); renderCard(); return     // nothing new copied — keep current drafts
         }
         draftFromClipboard()
+    }
+
+    /// Show drafts a screenshot capture staged for us. Marks the capture consumed
+    /// immediately so a keyboard re-appear can't replay it.
+    private func consumeStaged(_ staged: StagedScreenshotDraft) {
+        SharedStore.markStagedScreenshotConsumed()
+        lastChangeCount = UIPasteboard.general.changeCount   // ignore the clipboard for this turn
+        currentSource = staged.source
+        sourceMessages = staged.messages
+
+        if !staged.drafts.isEmpty {
+            drafts = staged.drafts
+            index = 0
+            renderCard()
+            showResults()                                    // finished drafts — no network
+        } else if staged.limitReached {
+            showStatus("You're out of free drafts today — open Flynn to go unlimited.")
+        } else {
+            runDraft(messages: staged.messages)              // needsDraft — generate now
+        }
     }
 
     private func draftFromClipboard() {
@@ -222,14 +282,22 @@ final class KeyboardViewController: UIInputViewController {
         }
 
         let messages = SharedStore.appendCopiedMessage(copied)
+        currentSource = "clipboard"
+        runDraft(messages: messages)
+    }
+
+    /// Fetch drafts for the given messages and render them. Shared by the clipboard
+    /// path and the screenshot `needsDraft` path (which sets `currentSource` first).
+    private func runDraft(messages: [String]) {
         isDrafting = true
+        sourceMessages = messages
         showStatus("Drafting in your voice…")
         spinner.startAnimating()
 
         Task { @MainActor in
             defer { spinner.stopAnimating(); isDrafting = false }
             do {
-                let result = try await KeyboardDraftClient.fetchDrafts(messages: messages)
+                let result = try await KeyboardDraftClient.fetchDrafts(messages: messages, source: currentSource)
                 if result.isEmpty {
                     showStatus("Couldn't draft anything — tap ↻ Redraft to try again.")
                 } else {
@@ -271,9 +339,19 @@ final class KeyboardViewController: UIInputViewController {
         guard drafts.indices.contains(index) else { return }
         let draft = drafts[index]
         textDocumentProxy.insertText(draft)
-        KeyboardDraftClient.recordAccepted(text: draft)
+        // Log the pick WITH the candidate set + index + source so the backend learns
+        // which option the user preferred (substance), not just the chosen text (voice).
+        KeyboardDraftClient.recordAccepted(
+            text: draft,
+            source: currentSource,
+            candidates: drafts,
+            pickedIndex: index,
+            messages: sourceMessages.isEmpty ? nil : sourceMessages
+        )
         SharedStore.resetThread()
         drafts = []
+        currentSource = "clipboard"
+        sourceMessages = []
         showStatus("Inserted ✓  — switch back to send.")
     }
 }

--- a/ios-native/Shared/DraftModels.swift
+++ b/ios-native/Shared/DraftModels.swift
@@ -5,11 +5,15 @@ struct DraftRequest: Encodable {
     let messages: [String]
     let draftCount: Int?
     let proposedSlots: [String]?
+    /// Where the customer messages came from: "clipboard" (copy→keyboard) or
+    /// "screenshot" (gesture capture). Used for analytics only; optional/back-compatible.
+    let source: String?
 
-    init(messages: [String], draftCount: Int? = 4, proposedSlots: [String]? = nil) {
+    init(messages: [String], draftCount: Int? = 4, proposedSlots: [String]? = nil, source: String? = nil) {
         self.messages = messages
         self.draftCount = draftCount
         self.proposedSlots = proposedSlots
+        self.source = source
     }
 }
 
@@ -17,6 +21,27 @@ struct DraftResponse: Decodable {
     let drafts: [String]
 }
 
+/// Records which draft the user inserted, plus the full candidate set and pick
+/// index so the backend can learn substance preferences (not just voice). All
+/// fields except `text` are optional to keep the clipboard path back-compatible.
 struct AcceptDraftRequest: Encodable {
     let text: String
+    let candidates: [String]?
+    let pickedIndex: Int?
+    let source: String?
+    let messages: [String]?
+
+    init(
+        text: String,
+        candidates: [String]? = nil,
+        pickedIndex: Int? = nil,
+        source: String? = nil,
+        messages: [String]? = nil
+    ) {
+        self.text = text
+        self.candidates = candidates
+        self.pickedIndex = pickedIndex
+        self.source = source
+        self.messages = messages
+    }
 }

--- a/ios-native/Shared/KeyboardDraftClient.swift
+++ b/ios-native/Shared/KeyboardDraftClient.swift
@@ -1,8 +1,10 @@
 import Foundation
 
-/// Network client used by the keyboard extension. Calls the backend with the
+/// Network client for the drafting endpoints. Calls the backend with the
 /// long-lived keyboard JWT (minted by the main app, read from the shared
-/// keychain). Kept tiny and dependency-free to respect the keyboard's memory cap.
+/// keychain). Lives in `Shared/` so BOTH the keyboard extension and the
+/// app-process `ScreenshotDraftIntent` can reuse it. Kept tiny and
+/// dependency-free to respect the keyboard's memory cap.
 enum KeyboardDraftClient {
     enum ClientError: Error {
         case notConfigured        // missing API base URL or token
@@ -17,7 +19,7 @@ enum KeyboardDraftClient {
     }
 
     /// Fetch reply drafts for the accumulated customer messages.
-    static func fetchDrafts(messages: [String]) async throws -> [String] {
+    static func fetchDrafts(messages: [String], source: String? = nil) async throws -> [String] {
         guard let base = baseURL(), let token = SharedSecureStore.keyboardToken else {
             throw ClientError.notConfigured
         }
@@ -27,7 +29,7 @@ enum KeyboardDraftClient {
         req.timeoutInterval = 8
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try JSONEncoder().encode(DraftRequest(messages: messages))
+        req.httpBody = try JSONEncoder().encode(DraftRequest(messages: messages, source: source))
 
         let (data, response) = try await URLSession.shared.data(for: req)
         guard let http = response as? HTTPURLResponse else { throw ClientError.server(-1) }
@@ -39,16 +41,31 @@ enum KeyboardDraftClient {
         return decoded.drafts
     }
 
-    /// Best-effort: tell the backend which draft the user accepted (learning loop).
+    /// Best-effort: tell the backend which draft the user accepted, with the full
+    /// candidate set + pick index + source so it can learn voice AND substance.
     /// Fire-and-forget; never throws into the UI.
-    static func recordAccepted(text: String) {
+    static func recordAccepted(
+        text: String,
+        source: String = "clipboard",
+        candidates: [String]? = nil,
+        pickedIndex: Int? = nil,
+        messages: [String]? = nil
+    ) {
         guard let base = baseURL(), let token = SharedSecureStore.keyboardToken else { return }
         var req = URLRequest(url: base.appendingPathComponent("api/keyboard/accept-draft"))
         req.httpMethod = "POST"
         req.timeoutInterval = 6
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try? JSONEncoder().encode(AcceptDraftRequest(text: text))
+        req.httpBody = try? JSONEncoder().encode(
+            AcceptDraftRequest(
+                text: text,
+                candidates: candidates,
+                pickedIndex: pickedIndex,
+                source: source,
+                messages: messages
+            )
+        )
         let task = URLSession.shared.dataTask(with: req)
         task.resume()
     }

--- a/ios-native/Shared/SharedConstants.swift
+++ b/ios-native/Shared/SharedConstants.swift
@@ -21,6 +21,8 @@ enum FlynnShared {
         static let threadKey = "flynn.thread.key"
         static let threadMessages = "flynn.thread.messages"
         static let threadUpdatedAt = "flynn.thread.updatedAt"
+        /// Drafts staged by the screenshot App Intent for the keyboard to display.
+        static let stagedScreenshot = "flynn.staged.screenshot"
     }
 
     /// Keychain account name for the keyboard JWT.
@@ -29,4 +31,9 @@ enum FlynnShared {
     /// A new copy that lands more than this many seconds after the last one starts
     /// a fresh conversation thread instead of appending.
     static let threadResetWindowSeconds: TimeInterval = 600
+
+    /// A staged screenshot capture older than this is ignored by the keyboard, so a
+    /// stale capture never overrides a fresh clipboard copy. Sized to comfortably
+    /// cover the gesture → app-switch → open-keyboard hop.
+    static let stagedDraftFreshnessSeconds: TimeInterval = 90
 }

--- a/ios-native/Shared/SharedStore.swift
+++ b/ios-native/Shared/SharedStore.swift
@@ -89,4 +89,49 @@ enum SharedStore {
         defaults?.removeObject(forKey: FlynnShared.DefaultsKey.threadMessages)
         defaults?.removeObject(forKey: FlynnShared.DefaultsKey.threadUpdatedAt)
     }
+
+    // MARK: Staged screenshot capture (App Intent → keyboard)
+
+    private static var stagedEncoder: JSONEncoder {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .secondsSince1970
+        return e
+    }
+
+    private static var stagedDecoder: JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .secondsSince1970
+        return d
+    }
+
+    /// Called by the screenshot App Intent to hand a capture to the keyboard.
+    static func stageScreenshotDraft(_ staged: StagedScreenshotDraft) {
+        guard let data = try? stagedEncoder.encode(staged) else { return }
+        defaults?.set(data, forKey: FlynnShared.DefaultsKey.stagedScreenshot)
+    }
+
+    /// The keyboard reads this on appear. Returns `nil` if there's nothing staged,
+    /// it's already been consumed, or it's older than the freshness window — so a
+    /// stale capture never overrides a fresh clipboard copy.
+    static func freshStagedScreenshotDraft() -> StagedScreenshotDraft? {
+        guard
+            let data = defaults?.data(forKey: FlynnShared.DefaultsKey.stagedScreenshot),
+            let staged = try? stagedDecoder.decode(StagedScreenshotDraft.self, from: data),
+            !staged.consumed,
+            Date().timeIntervalSince(staged.capturedAt) <= FlynnShared.stagedDraftFreshnessSeconds
+        else { return nil }
+        return staged
+    }
+
+    /// Mark the staged capture consumed so a keyboard re-appear doesn't replay it.
+    static func markStagedScreenshotConsumed() {
+        guard
+            let data = defaults?.data(forKey: FlynnShared.DefaultsKey.stagedScreenshot),
+            var staged = try? stagedDecoder.decode(StagedScreenshotDraft.self, from: data)
+        else { return }
+        staged.consumed = true
+        if let updated = try? stagedEncoder.encode(staged) {
+            defaults?.set(updated, forKey: FlynnShared.DefaultsKey.stagedScreenshot)
+        }
+    }
 }

--- a/ios-native/Shared/StagedScreenshotDraft.swift
+++ b/ios-native/Shared/StagedScreenshotDraft.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A capture staged by the screenshot `ScreenshotDraftIntent` (app process) for the
+/// keyboard extension to pick up on its next appearance. Written to the App Group as
+/// a single JSON blob so the hand-off is atomic across processes.
+///
+/// The intent runs on a tight background budget, so it never blocks: on success it
+/// stages finished `drafts`; if the draft call can't run it stages the OCR'd
+/// `messages` with `needsDraft = true` and the keyboard generates them instead.
+struct StagedScreenshotDraft: Codable, Sendable {
+    /// The OCR'd customer message(s) extracted from the screenshot.
+    let messages: [String]
+    /// Finished replies. Empty when `needsDraft` or `limitReached`.
+    let drafts: [String]
+    /// Always "screenshot" — tags pick-logging so the backend learns by source.
+    let source: String
+    let capturedAt: Date
+    /// Set once the keyboard has shown this capture so a re-appear can't replay it.
+    var consumed: Bool
+    /// The keyboard should call the draft API itself (token/network was unavailable).
+    let needsDraft: Bool
+    /// The free-tier daily cap was hit (HTTP 402); the keyboard shows the limit copy.
+    let limitReached: Bool
+
+    init(
+        messages: [String],
+        drafts: [String] = [],
+        source: String = "screenshot",
+        capturedAt: Date = Date(),
+        consumed: Bool = false,
+        needsDraft: Bool = false,
+        limitReached: Bool = false
+    ) {
+        self.messages = messages
+        self.drafts = drafts
+        self.source = source
+        self.capturedAt = capturedAt
+        self.consumed = consumed
+        self.needsDraft = needsDraft
+        self.limitReached = limitReached
+    }
+}

--- a/server.js
+++ b/server.js
@@ -2334,7 +2334,8 @@ app.post('/api/keyboard/provision-token', authenticateJwt, async (req, res) => {
  * messages. Used by the keyboard extension. Privacy: customer message text is
  * used only to build the prompt and is NOT persisted.
  * POST /api/keyboard/draft-replies
- * Body: { messages: string[], proposedSlots?: string[], draftCount?: number }
+ * Body: { messages: string[], proposedSlots?: string[], draftCount?: number,
+ *         source?: 'clipboard'|'screenshot' }
  */
 app.post('/api/keyboard/draft-replies', authenticateJwt, async (req, res) => {
   const userId = req.user?.id;
@@ -2355,6 +2356,9 @@ app.post('/api/keyboard/draft-replies', authenticateJwt, async (req, res) => {
     ? req.body.proposedSlots.filter((s) => typeof s === 'string' && s.trim()).slice(0, 5)
     : [];
   const draftCount = Math.min(Math.max(parseInt(req.body?.draftCount, 10) || 4, 1), 4);
+  // How the conversation was captured: 'screenshot' (gesture) or 'clipboard'
+  // (copy→keyboard). Tweaks the prompt framing; defaults to clipboard.
+  const source = req.body?.source === 'screenshot' ? 'screenshot' : 'clipboard';
 
   try {
     // Free-tier gate: unlimited for entitled users; capped per day otherwise.
@@ -2403,9 +2407,13 @@ app.post('/api/keyboard/draft-replies', authenticateJwt, async (req, res) => {
     const { drafts, usage } = await generateDrafts({
       profileRow: profileRow || {},
       toneSamples,
+      // The accepted samples are exactly the replies the user has picked before —
+      // used to derive substance preferences (length, price, time, emoji, greeting).
+      pickedSamples: accepted,
       messages,
       proposedSlots,
       draftCount,
+      source,
     });
 
     if (!drafts || drafts.length === 0) {
@@ -2426,9 +2434,12 @@ app.post('/api/keyboard/draft-replies', authenticateJwt, async (req, res) => {
 
 /**
  * Learning loop: record a draft the user actually tapped/sent so future drafts
- * lean toward that style. Stored as a tone sample with source='accepted'.
+ * lean toward that style (voice) AND substance. The accepted text is stored as a
+ * tone sample (source='accepted'); the full candidate set + picked index + source
+ * + conversation are stored in draft_picks for contrastive/substance learning.
  * POST /api/keyboard/accept-draft
- * Body: { text: string }
+ * Body: { text: string, candidates?: string[], pickedIndex?: number,
+ *         source?: 'clipboard'|'screenshot', messages?: string[] }
  */
 app.post('/api/keyboard/accept-draft', authenticateJwt, async (req, res) => {
   const userId = req.user?.id;
@@ -2438,6 +2449,16 @@ app.post('/api/keyboard/accept-draft', authenticateJwt, async (req, res) => {
   const text = typeof req.body?.text === 'string' ? req.body.text.trim() : '';
   if (!text) return res.status(400).json({ error: 'No draft text provided' });
 
+  // Optional richer learning signals (back-compatible: clipboard path may omit them).
+  const candidates = Array.isArray(req.body?.candidates)
+    ? req.body.candidates.filter((c) => typeof c === 'string').map((c) => c.slice(0, 1000)).slice(0, 8)
+    : [];
+  const messages = Array.isArray(req.body?.messages)
+    ? req.body.messages.filter((m) => typeof m === 'string').map((m) => m.slice(0, 2000)).slice(0, 20)
+    : [];
+  const pickedIndex = Number.isInteger(req.body?.pickedIndex) ? req.body.pickedIndex : null;
+  const source = req.body?.source === 'screenshot' ? 'screenshot' : 'clipboard';
+
   try {
     const { error } = await supabaseStorageClient
       .from('tone_samples')
@@ -2446,6 +2467,21 @@ app.post('/api/keyboard/accept-draft', authenticateJwt, async (req, res) => {
       console.error('[Keyboard] accept-draft insert failed:', error.message);
       return res.status(500).json({ error: 'Failed to record accepted draft' });
     }
+
+    // Best-effort: never fail the request if the richer record can't be written.
+    try {
+      await supabaseStorageClient.from('draft_picks').insert({
+        user_id: userId,
+        messages,
+        candidates,
+        picked_index: pickedIndex,
+        picked_text: text.slice(0, 1000),
+        source,
+      });
+    } catch (pickErr) {
+      console.warn('[Keyboard] draft_picks insert failed (non-fatal):', pickErr?.message);
+    }
+
     res.json({ success: true });
   } catch (error) {
     console.error('[Keyboard] accept-draft failed:', error?.message);

--- a/services/draftReplies.js
+++ b/services/draftReplies.js
@@ -47,15 +47,66 @@ const profileRowToContext = (row = {}) => {
   };
 };
 
+const EMOJI_RE = /[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2190}-\u{21FF}\u{2B00}-\u{2BFF}\u{FE0F}]/u;
+const PRICE_RE = /(\$\s?\d|\bquote\b|\bprice[ds]?\b|\bcost[s]?\b|\bper hour\b|\b\d+\s?(?:dollars|bucks)\b)/i;
+const TIME_RE = /\b(mon|tue|wed|thu|fri|sat|sun|today|tomorrow|tonight|morning|afternoon|evening|\d{1,2}(?::\d{2})?\s?(?:am|pm)|\d{1,2}\s?(?:am|pm))\b/i;
+const GREETING_RE = /^(hi|hey|hello|g'?day|gday|morning|cheers|yo)\b/i;
+
+/**
+ * Derive lightweight "substance" preferences from the replies the owner has
+ * picked before (passive learning beyond pure voice mimicry). Pure heuristics,
+ * no extra model call. Returns a compact instruction block, or '' when there
+ * isn't enough signal yet.
+ */
+const deriveLearnedPreferences = (pickedSamples = []) => {
+  const samples = (pickedSamples || [])
+    .filter((s) => typeof s === 'string' && s.trim().length > 0)
+    .slice(0, 25);
+  if (samples.length < 3) return ''; // not enough history to be confident
+
+  const n = samples.length;
+  const frac = (pred) => samples.filter(pred).length / n;
+  const avgWords =
+    samples.reduce((sum, s) => sum + s.trim().split(/\s+/).length, 0) / n;
+
+  const lines = [];
+  // Length: only assert when consistently short or notably long.
+  if (avgWords <= 14) lines.push(`- Keep replies short (around ${Math.round(avgWords)} words).`);
+  else if (avgWords >= 30) lines.push(`- Replies tend to be longer (around ${Math.round(avgWords)} words).`);
+
+  const priceFrac = frac((s) => PRICE_RE.test(s));
+  if (priceFrac >= 0.6) lines.push('- Usually mentions a price, quote or cost.');
+  else if (priceFrac <= 0.15) lines.push('- Rarely talks price up front.');
+
+  const timeFrac = frac((s) => TIME_RE.test(s));
+  if (timeFrac >= 0.6) lines.push('- Often offers a specific day or time.');
+
+  const emojiFrac = frac((s) => EMOJI_RE.test(s));
+  if (emojiFrac >= 0.5) lines.push('- Often uses an emoji.');
+  else if (emojiFrac <= 0.1) lines.push('- Rarely uses emoji.');
+
+  const greetFrac = frac((s) => GREETING_RE.test(s.trim()));
+  if (greetFrac >= 0.6) lines.push('- Usually opens with a quick greeting.');
+  else if (greetFrac <= 0.15) lines.push('- Usually skips a greeting and gets to the point.');
+
+  if (lines.length === 0) return '';
+  return [
+    'Learned preferences — patterns from replies this owner has actually picked before. Lean toward these (they describe substance, not just style):',
+    lines.join('\n'),
+  ].join('\n');
+};
+
 /**
  * Build the system + user prompt for a draft request.
  */
 const buildPrompt = ({
   businessBrainText = '',
   toneSamples = [],
+  pickedSamples = [],
   messages = [],
   proposedSlots = [],
   draftCount = DEFAULT_DRAFT_COUNT,
+  source = null,
 }) => {
   const systemParts = [
     'You draft SMS replies for a small-business owner (often a sole-trader tradesperson) replying to a customer who messaged them.',
@@ -69,6 +120,11 @@ const buildPrompt = ({
     );
   } else {
     systemParts.push('Write in a warm, natural, casual human voice — never stiff or corporate.');
+  }
+
+  const learnedPreferences = deriveLearnedPreferences(pickedSamples);
+  if (learnedPreferences) {
+    systemParts.push(learnedPreferences);
   }
 
   if (businessBrainText) {
@@ -90,10 +146,17 @@ const buildPrompt = ({
     `Respond with ONLY a JSON object of the form {"drafts": ["reply 1", "reply 2", ...]} containing EXACTLY ${draftCount} distinct reply options. No other keys, no prose, no markdown.`
   );
 
-  const userText = [
-    'The customer sent the following (it may arrive in fragments — treat it as one conversation):',
-    messages.map((m) => `- ${m}`).join('\n'),
-  ].join('\n');
+  // Screenshot captures contain the whole visible conversation (both sides + app
+  // chrome); clipboard captures are just the customer's copied message(s).
+  const userText = source === 'screenshot'
+    ? [
+        "This is the text Flynn read from a screenshot of the conversation — it may include BOTH the customer's messages and the owner's own earlier replies, plus app chrome like names and timestamps. Focus on the latest customer message and draft the owner's next reply:",
+        messages.join('\n'),
+      ].join('\n')
+    : [
+        'The customer sent the following (it may arrive in fragments — treat it as one conversation):',
+        messages.map((m) => `- ${m}`).join('\n'),
+      ].join('\n');
 
   return {
     system: systemParts.join('\n\n'),
@@ -137,9 +200,11 @@ const parseDrafts = (content, draftCount) => {
 const generateDrafts = async ({
   profileRow = {},
   toneSamples = [],
+  pickedSamples = [],
   messages = [],
   proposedSlots = [],
   draftCount = DEFAULT_DRAFT_COUNT,
+  source = null,
 } = {}) => {
   const cleanedMessages = (messages || [])
     .map((m) => (typeof m === 'string' ? m.trim() : ''))
@@ -153,9 +218,11 @@ const generateDrafts = async ({
   const { system, user } = buildPrompt({
     businessBrainText,
     toneSamples,
+    pickedSamples,
     messages: cleanedMessages,
     proposedSlots,
     draftCount,
+    source,
   });
 
   const client = getLLMClient('compatible');
@@ -179,6 +246,7 @@ const generateDrafts = async ({
 module.exports = {
   DEFAULT_DRAFT_COUNT,
   profileRowToContext,
+  deriveLearnedPreferences,
   buildPrompt,
   parseDrafts,
   generateDrafts,

--- a/supabase/migrations/20260605000000_create_draft_picks.sql
+++ b/supabase/migrations/20260605000000_create_draft_picks.sql
@@ -1,0 +1,62 @@
+-- Draft picks for Flynn's text-reply co-pilot (passive learning, voice + substance).
+--
+-- tone_samples already captures the *accepted text* (voice). draft_picks captures
+-- the richer signal: the full candidate set the user chose from, which option they
+-- picked, the source conversation, and how it was captured (clipboard vs
+-- screenshot). This contrastive data (chosen vs not-chosen) powers substance
+-- learning now and richer preference modelling later.
+--
+-- Privacy: customer message text is sensitive; rows are owned by the user and
+-- protected by RLS. Stored to learn the owner's preferences, never shared.
+
+CREATE TABLE IF NOT EXISTS public.draft_picks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  org_id UUID REFERENCES public.organizations(id) ON DELETE CASCADE,
+  -- The conversation the drafts responded to (OCR'd screen or copied message[s]).
+  messages JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- The full set of options shown to the user.
+  candidates JSONB NOT NULL DEFAULT '[]'::jsonb,
+  -- Which option (0-based) they inserted, and its text.
+  picked_index INTEGER,
+  picked_text TEXT NOT NULL,
+  -- How the conversation was captured.
+  source TEXT NOT NULL DEFAULT 'clipboard'
+    CHECK (source IN ('clipboard', 'screenshot')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fetch a user's picks newest-first (substance derivation reads the latest).
+CREATE INDEX IF NOT EXISTS draft_picks_user_created_idx
+  ON public.draft_picks (user_id, created_at DESC);
+
+-- Auto-fill user_id/org_id on insert, mirroring tone_samples_set_owner.
+CREATE OR REPLACE FUNCTION public.draft_picks_set_owner()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF NEW.user_id IS NULL THEN
+    NEW.user_id := auth.uid();
+  END IF;
+  IF NEW.org_id IS NULL THEN
+    SELECT default_org_id INTO NEW.org_id
+    FROM public.users
+    WHERE id = NEW.user_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_draft_picks_set_owner ON public.draft_picks;
+CREATE TRIGGER trg_draft_picks_set_owner
+  BEFORE INSERT ON public.draft_picks
+  FOR EACH ROW EXECUTE FUNCTION public.draft_picks_set_owner();
+
+-- RLS: a user manages only their own picks (mirrors tone_samples policy).
+ALTER TABLE public.draft_picks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can manage own draft picks" ON public.draft_picks;
+CREATE POLICY "Users can manage own draft picks"
+ON public.draft_picks
+FOR ALL
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## What
Makes the **gesture → screenshot → on-device OCR → staged drafts → keyboard** path the *recommended* capture flow, while keeping **copy → keyboard** as the second onboarding option and universal fallback.

## iOS
- **`ScreenshotDraftIntent`** — background App Intent (`openAppWhenRun = false`). Takes the Shortcuts **Take Screenshot** image via `IntentFile`, OCRs on-device (Vision `RecognizeTextRequest`, `.accurate` + language correction), drafts replies, and stages them in the App Group. **Never reads the clipboard** (no "pasting from…" banner), **never saves to the camera roll**. `FlynnShortcuts: AppShortcutsProvider` exposes it to Shortcuts.
- **Resilient fallback ladder**: no token/offline → stage OCR'd messages with `needsDraft`; 402 → `limitReached` marker; success → finished drafts. Keyboard is never a dead end.
- **`KeyboardDraftClient` moved to `Shared/`** so the app-process intent and keyboard both reuse it. New `StagedScreenshotDraft` model + `SharedStore` staging API.
- **Keyboard** checks `freshStagedScreenshotDraft()` (90s window, consumed flag) *before* the clipboard path — copy→keyboard is byte-identical when nothing is staged.
- **Onboarding** — new final `captureSetup` step (`CaptureSetupStepView`): screenshot (RECOMMENDED) vs copy & paste. Device-aware gesture setup via `DeviceCapability.hasActionButton` (Action Button single-press, warned it replaces the default, + Back Tap alternative; non-AB devices get Back Tap triple-tap). `FlynnConfig.captureShortcutURL` placeholder for the iCloud link.

> **Action Button double-press was dropped** — verified not achievable on iOS (Apple allows one action per press; the MultiButton trick seizes the whole button).

## Backend — passive learning (voice + substance, no new prompts)
- New **`draft_picks`** table (candidates, picked index, source, conversation) — migration applied to the `Flynnai` Supabase project.
- `accept-draft` logs the full pick; `draft-replies` derives substance preferences (length, price, time, emoji, greeting) from prior picks into a "Learned preferences" block, plus screenshot-aware prompt framing. All additive / back-compatible.

## Heads-up for review
- Two files carry **pre-existing uncommitted working-tree edits** that aren't part of this feature: `KeyboardViewController.swift` (keyboard cream-UI redesign) and `OnboardingStore.swift` (`single()`→`limit(1)` new-user fix). They were already in the working tree; they ride along because they're in the same files.
- **Blocked handoff**: `FlynnConfig.captureShortcutURL` is `nil` until the iCloud Shortcut link is published (see comment below) — onboarding shows manual build steps until then.

## Verification
- `xcodegen generate` + `xcodebuild` → **BUILD SUCCEEDED** (app + keyboard).
- `node --check` on `server.js` / `draftReplies.js`; substance heuristic spot-tested.
- Migration applied via Supabase MCP (`success: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)