### PR TITLE
Fix screenshot shortcut wiring (parameterSummary) + bump to 3.0.1 (89)

### DIFF
--- a/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotDraftIntent.swift
+++ b/ios-native/FlynnAI/Features/ScreenshotIntent/ScreenshotDraftIntent.swift
@@ -22,8 +22,15 @@ struct ScreenshotDraftIntent: AppIntent {
     /// to the messaging app + keyboard.
     static let openAppWhenRun: Bool = false
 
-    @Parameter(title: "Screenshot", supportedContentTypes: [.image])
+    @Parameter(title: "Screenshot", description: "The screenshot to read.", supportedContentTypes: [.image])
     var screenshot: IntentFile
+
+    /// Renders `screenshot` as an inline placeholder in the Shortcuts editor so the
+    /// "Take Screenshot" action's output attaches as a magic variable — instead of
+    /// the bare file-picker "Choose" row you get with no summary.
+    static var parameterSummary: some ParameterSummary {
+        Summary("Draft a reply from \(\.$screenshot)")
+    }
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {

--- a/ios-native/project.yml
+++ b/ios-native/project.yml
@@ -52,8 +52,8 @@ targets:
       properties:
         CFBundleName: $(PRODUCT_NAME)
         CFBundleDisplayName: Flynn
-        CFBundleShortVersionString: "3.0.0"
-        CFBundleVersion: "88"
+        CFBundleShortVersionString: "3.0.1"
+        CFBundleVersion: "89"
         CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
         UILaunchScreen:
           UIColorName: ""
@@ -102,8 +102,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.flynnai.app
-        MARKETING_VERSION: "3.0.0"
-        CURRENT_PROJECT_VERSION: "88"
+        MARKETING_VERSION: "3.0.1"
+        CURRENT_PROJECT_VERSION: "89"
         TARGETED_DEVICE_FAMILY: "1,2"
         ENABLE_PREVIEWS: YES
         DEVELOPMENT_TEAM: "69T5H7R46N"
@@ -135,8 +135,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.flynnai.app.keyboard
         PRODUCT_NAME: FlynnKeyboard
-        MARKETING_VERSION: "3.0.0"
-        CURRENT_PROJECT_VERSION: "88"
+        MARKETING_VERSION: "3.0.1"
+        CURRENT_PROJECT_VERSION: "89"
         TARGETED_DEVICE_FAMILY: "1,2"
         DEVELOPMENT_TEAM: "69T5H7R46N"
         CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Problem
When building the **Take Screenshot → Capture with Flynn** shortcut, the intent's `Screenshot` input only showed a **"Choose"** link that opened the **Files** picker — there was no way to attach the Take Screenshot output as a magic variable. So the shortcut couldn't be wired up.

## Fix
Added a **`parameterSummary`** to `ScreenshotDraftIntent`:
```swift
static var parameterSummary: some ParameterSummary {
    Summary("Draft a reply from \(\.$screenshot)")
}
```
Per [Apple's App Intents docs](https://developer.apple.com/documentation/appintents/adding-parameters-to-an-app-intent), a parameter must appear in the parameter summary to be an **interactive placeholder** in the Shortcuts editor. Without it, a file parameter renders as choose-from-Files only; with it, the **Take Screenshot** output attaches as a magic variable.

Also added a `description` to the parameter for clarity.

## Version
Bumps **3.0.0 → 3.0.1 (build 89)**. The 3.0.0 train is closed on App Store Connect (3.0.0 is already live), and 3.0.1 is the release that carries the screenshot-capture feature. (The version bump that was previously uncommitted now lands here.)

## Note
The hard constraint stands: an app can't screenshot other apps — only the Shortcuts **Take Screenshot** action can grab the current screen (and without saving to the camera roll), so the 2-action shortcut is required. This fix just makes that action's output connect properly.

## Verification
- `xcodegen generate` + `xcodebuild` → **BUILD SUCCEEDED** (app + keyboard).
- Editor wiring to be confirmed on-device once 3.0.1 is installed (that's the remaining manual check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)